### PR TITLE
[18.0][FIX] repair_order_group: keep groups only for draft duplicates

### DIFF
--- a/repair_order_group/models/repair_order.py
+++ b/repair_order_group/models/repair_order.py
@@ -43,6 +43,19 @@ class RepairOrder(models.Model):
                 continue
             repair.grouped_repair_ids = repair.group_id.repair_ids - repair
 
+    def copy(self, default=None):
+        """Keep the group only for draft repairs when duplicating.
+
+        Duplicating a grouped repair order:
+        - if original is in Draft -> duplicated repair stays in the same group
+        - otherwise -> duplicated repair is not assigned to any group
+        """
+        self.ensure_one()
+        default = dict(default or {})
+        if self.group_id and self.state != "draft":
+            default["group_id"] = False
+        return super().copy(default)
+
     def action_add_another_repair(self):
         """Create a new empty repair linked to the same group.
 

--- a/repair_order_group/tests/test_repair_order_group.py
+++ b/repair_order_group/tests/test_repair_order_group.py
@@ -659,3 +659,60 @@ class TestRepairOrderGroup(TransactionCase):
 
         repair.action_repair_cancel()
         self.assertEqual(repair.state, "cancel")
+
+    def test_22_duplicate_grouped_repair_keeps_group_in_draft(self):
+        """Draft repair duplication keeps the same group."""
+        group = self.env["repair.order.group"].create({"partner_id": self.partner.id})
+        repair = self.env["repair.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": self.picking_type.id,
+                "product_id": self.product.id,
+                "group_id": group.id,
+            }
+        )
+
+        self.env["repair.service"].create(
+            {
+                "repair_id": repair.id,
+                "product_id": self.product.id,
+            }
+        )
+
+        duplicated = repair.copy()
+
+        self.assertEqual(
+            duplicated.group_id,
+            repair.group_id,
+            "Draft grouped repair should remain in the same group when duplicated.",
+        )
+
+    def test_23_duplicate_grouped_repair_drops_group_outside_draft(self):
+        """Non-draft repair duplication must not keep the group."""
+        group = self.env["repair.order.group"].create({"partner_id": self.partner.id})
+        repair = self.env["repair.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": self.picking_type.id,
+                "product_id": self.product.id,
+                "group_id": group.id,
+            }
+        )
+
+        self.env["repair.service"].create(
+            {
+                "repair_id": repair.id,
+                "product_id": self.product.id,
+            }
+        )
+
+        repair.action_validate()
+        repair._action_repair_confirm()
+
+        duplicated = repair.copy()
+
+        self.assertFalse(
+            duplicated.group_id,
+            "Non-draft grouped repair should not be assigned "
+            "to a group when duplicated.",
+        )


### PR DESCRIPTION
Duplicating grouped repairs after draft can unintentionally keep them tied to the original group, mixing operational flows and shared quotations. Restrict group propagation to draft repairs to match expected usage.

Task: 5252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate behavior updated: copying a repair in draft retains its group; copying a non-draft repair removes its group association.

* **Tests**
  * Added tests to verify duplication preserves group for drafts and clears group for non-draft repairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->